### PR TITLE
Fix/typos

### DIFF
--- a/format-dgc-acquired-trend.md
+++ b/format-dgc-acquired-trend.md
@@ -9,12 +9,12 @@
 
 | Field Name                  | Description (ITA)                       | Description                            | Format                       | Example             |
 |-----------------------------|-----------------------------------|----------------------------------------|-------------------------------|---------------------|
-| **data**                    | Data di riferimento            | reference data                   | YYYY-MM-DD | 2021-06-17 |
+| **data**                    | data di riferimento            | reference date                   | YYYY-MM-DD | 2021-06-17 |
 | **acquired_by_app_immuni**  | numero giornaliero di DGC acquisiti tramite l'app "Immuni" | daily number of DGC acquired through the "Immuni" app      |  number     |         3         |
 | **acquired_by_web_ts**      | numero giornaliero di DGC acquisiti tramite portale il portale dgc.gov.it utilizzando la tessera sanitaria | daily number of DGC acquired through the portal dgc.gov.it using the "Tessera Sanitaria" |  number                        | 3                  |
 | **acquired_by_web_id**      | numero giornaliero di DGC acquisiti tramite portale il portale dgc.gov.it utilizzando un documento di riconoscimento| daily number of DGC acquired through the portal dgc.gov.it using the identification document | number             | 3             |
 | **acquired_by_web_spid**    | numero giornaliero di DGC acquisiti tramite portale il portale dgc.gov.it utilizzando SPID | daily number of DGC acquired through the portal dgc.gov.it using SPID | number                         | 3          |
-| **acquired_by_operator_ts** | numero giornaliero di DGC acquisiti tramite oepratore utilizzando la tessera sanitaria | daily number of DGC acquired through the operator using the "Tessera Sanitaria" | number                         | 3          |
+| **acquired_by_operator_ts** | numero giornaliero di DGC acquisiti tramite operatore utilizzando la tessera sanitaria | daily number of DGC acquired through the operator using the "Tessera Sanitaria" | number                         | 3          |
 | **acquired_by_operator_id** | numero giornaliero di DGC acquisiti tramite operatore utilizzando un documento di riconoscimento | daily number of DGC acquired through the operator using the identification document | number                         | 3          |
 | **acquired_by_app_io**      | numero giornaliero di DGC acquisiti tramite l'app "IO" | daily number of DGC acquired through the "IO" app | number                         | 3          |
 | **acquired_all**            | numero giornaliero di DGC acquisiti complessivamente | daily number of DGC acquired overall | number                         | 3          |

--- a/format-dgc-issued-trend.md
+++ b/format-dgc-issued-trend.md
@@ -9,7 +9,7 @@
 
 | Field Name                  | Description (ITA)                       | Description                            | Format                       | Example             |
 |-----------------------------|-----------------------------------|----------------------------------------|-------------------------------|---------------------|
-| **data**                    | Data di riferimento            | reference data                   | YYYY-MM-DD | 2021-06-17 |
+| **data**                    | data di riferimento            | reference date                   | YYYY-MM-DD | 2021-06-17 |
 | **issued_for_vaccines**     | numero di DGC giornalieri emessi da vaccinazione | number of daily DGC issued by vaccination           |  number     |         3         |
 | **issued_for_tests**        | numero di DGC giornalieri emessi da test covid-19 (tampone) | number of daily DGC issued per covid-19 test        |  number                        | 3                  |
 | **issued_for_healing**      | numero di DGC giornalieri emessi da guarigione dal covid-19        | number of daily DGC issued by covid-19 healing                     | number             | 3             |


### PR DESCRIPTION
- I think "reference **data**" should be "reference **date**" in english.
- Also removed capital "D" on "Data di riferimento" in descriptions (all other descriptions start with lower-case letters).
- Fixed a typo: "operatore" in `format-dgc-acquired-trend.md` (it was "oepratore").